### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Bot Advanced
+description: Advanced bot defense with behavioral analysis for F5 Distributed Cloud.
 hero:
   tagline: Advanced bot defense with behavioral analysis.
   image:


### PR DESCRIPTION
## Summary

- Adds a `description:` field to `docs/index.mdx` frontmatter so the starlight-llms-txt plugin includes page-level metadata in the llms.txt output.

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy -- adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #251

## Test plan

- [ ] CI checks pass
- [ ] Verify the frontmatter YAML is valid and includes the new `description:` field
- [ ] Confirm the docs site builds successfully